### PR TITLE
BUG in IMAP mail read in some cases

### DIFF
--- a/OpaqueMail/Imap/ImapClient.cs
+++ b/OpaqueMail/Imap/ImapClient.cs
@@ -2198,7 +2198,7 @@ namespace OpaqueMail
 
                 int bodyLength = -1;
                 int.TryParse(Functions.ReturnBetween(firstLine, "BODY[] {", "}"), out bodyLength);
-                if (bodyLength > 0)
+                if (bodyLength > 0 && response.Length > (bodyLength + lineBreak + 2))
                     response = response.Substring(lineBreak + 2, bodyLength);
                 else
                 {


### PR DESCRIPTION
In some cases the  variable "bodyLength" is bigger  than "response.Length" - I'm not have enough time to detect fully this BUG, but this solutions seems work. 
